### PR TITLE
Fixed the search function error caused by the admin-search.js file being included too early

### DIFF
--- a/web/app/templates/admin/users.html
+++ b/web/app/templates/admin/users.html
@@ -40,5 +40,9 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
 <script src="{{ url_for('static', filename='js/admin-search.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
The file was included in the content block instead of the script block
