### PR TITLE
Added routes, forms and views for managing work-periods

### DIFF
--- a/web/app/admin/forms.py
+++ b/web/app/admin/forms.py
@@ -35,3 +35,10 @@ class EditTeacherForm(Form):
 
 class ExcelUploadForm(Form):
     upload = FileField('Excel-dokument', validators=[FileRequired(), FileAllowed(['xlsx'])])
+
+
+class AddWorkPeriodForm(Form):
+    pass
+
+class EditWorkPeriodForm(Form):
+    pass

--- a/web/app/admin/forms.py
+++ b/web/app/admin/forms.py
@@ -3,6 +3,7 @@ from wtforms import StringField, PasswordField, SubmitField
 from flask_wtf.file import FileField, FileAllowed, FileRequired
 from wtforms.validators import Required, Length, Email, EqualTo, Regexp
 from wtforms import ValidationError
+from wtforms.fields.html5 import DateField
 from ..models import User
 import re
 
@@ -38,7 +39,12 @@ class ExcelUploadForm(Form):
 
 
 class AddWorkPeriodForm(Form):
-    pass
+    start = DateField('Startdatum', format='%Y-%m-%d', validators=[Required()])
+    end = DateField('Slutdatum', format='%Y-%m-%d', validators=[Required()])
+    submit = SubmitField('Spara')
+
 
 class EditWorkPeriodForm(Form):
-    pass
+    start = DateField('Startdatum', format='%Y-%m-%d', validators=[Required()])
+    end = DateField('Slutdatum', format='%Y-%m-%d', validators=[Required()])
+    submit = SubmitField('Spara')

--- a/web/app/admin/views.py
+++ b/web/app/admin/views.py
@@ -13,7 +13,11 @@ from flask.ext.login import (login_user,
 from . import admin
 from .. import db
 from ..decorators import admin_required, permission_required
-from .forms import AddTeacherForm, ExcelUploadForm, EditTeacherForm
+from .forms import (AddTeacherForm,
+                    ExcelUploadForm,
+                    EditTeacherForm,
+                    AddWorkPeriodForm,
+                    EditWorkPeriodForm)
 from ..models import User, WorkPeriod
 from sqlalchemy import desc
 
@@ -50,7 +54,7 @@ def add_teacher():
         db.session.commit()
         return redirect(url_for('admin.teachers'))
 
-    return render_template('admin/add.html', form=form)
+    return render_template('admin/add.html', form=form, form_name='lärare')
 
 
 @admin.route('/teachers/edit/<int:id>', methods=['GET', 'POST'])
@@ -65,7 +69,7 @@ def edit_teacher(id):
         db.session.commit()
         return redirect(url_for('admin.teachers'))
 
-    return render_template('admin/edit_teacher.html', form=form)
+    return render_template('admin/edit.html', form=form, form_name='lärare')
 
 
 @admin.route('/teachers/upload', methods=['GET', 'POST'])
@@ -84,12 +88,12 @@ def upload_teachers():
 @login_required
 @admin_required
 def work_periods():
-    work_periods = WorkPeriod.query.order_by(WorkPeriod.start)
+    work_periods = WorkPeriod.query.order_by(desc(WorkPeriod.start))
     # TODO - fix date-datatype and populate db
     return render_template('admin/work_periods.html', work_periods=work_periods)
 
 
-@admin.route('/work_periods/add', methods=['GET', 'POST'])
+@admin.route('/work-periods/add', methods=['GET', 'POST'])
 @login_required
 @admin_required
 def add_work_period():
@@ -101,7 +105,7 @@ def add_work_period():
         db.session.commit()
         return redirect(url_for('admin.work_periods'))
 
-    return render_template('admin/add.html', form=form)
+    return render_template('admin/add.html', form=form, form_name='arbetsperiod')
 
 
 @admin.route('/work-periods/edit/<int:id>', methods=['GET', 'POST'])
@@ -116,4 +120,4 @@ def edit_work_period(id):
         db.session.commit()
         return redirect(url_for('admin.work_periods'))
 
-    return render_template('admin/work_periods.html', form=form)
+    return render_template('admin/edit.html', form=form, form_name='arbetsperiod')

--- a/web/app/admin/views.py
+++ b/web/app/admin/views.py
@@ -14,7 +14,7 @@ from . import admin
 from .. import db
 from ..decorators import admin_required, permission_required
 from .forms import AddTeacherForm, ExcelUploadForm, EditTeacherForm
-from ..models import User
+from ..models import User, WorkPeriod
 from sqlalchemy import desc
 
 
@@ -78,3 +78,42 @@ def upload_teachers():
         pass
 
     return render_template('admin/upload.html', form=form)
+
+
+@admin.route('/work-periods/', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def work_periods():
+    work_periods = WorkPeriod.query.order_by(WorkPeriod.start)
+    # TODO - fix date-datatype and populate db
+    return render_template('admin/work_periods.html', work_periods=work_periods)
+
+
+@admin.route('/work_periods/add', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def add_work_period():
+    form = AddWorkPeriodForm()
+
+    if form.validate_on_submit():
+        work_period = WorkPeriod(start=form.start.data, end=form.end.data)
+        db.session.add(work_period)
+        db.session.commit()
+        return redirect(url_for('admin.work_periods'))
+
+    return render_template('admin/add.html', form=form)
+
+
+@admin.route('/work-periods/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_work_period(id):
+    work_period = WorkPeriod.query.filter_by(id=id).first()
+    form = EditWorkPeriodForm(obj=work_period)
+
+    if form.validate_on_submit():
+        form.populate_obj(work_period)
+        db.session.commit()
+        return redirect(url_for('admin.work_periods'))
+
+    return render_template('admin/work_periods.html', form=form)

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -214,7 +214,7 @@ class Deviation(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     date = db.Column(db.Date)
     start = db.Column(db.Time)
-    lund_start = db.Column(db.Time)
+    lunch_start = db.Column(db.Time)
     lunch_end = db.Column(db.Time)
     end = db.Column(db.Time)
     schedule_id = db.Column(db.Integer, db.ForeignKey("schedules.id"))
@@ -257,8 +257,9 @@ class WorkPeriod(db.Model):
     end = db.Column(db.Date)
     schedules = db.relationship('Schedule', backref='work_period', lazy='dynamic')
 
-    def __init__(self):
-        pass
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
 
 
 # Sets login_managers anonymous_user to AnonymousUser-class.

--- a/web/app/templates/admin/add.html
+++ b/web/app/templates/admin/add.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% import "bootstrap/wtf.html" as wtf %}
 
-{% block title %}Lägg till lärare{% endblock %}
+{% block title %}Lägg till {{ form_name }}{% endblock %}
 
 {% block page_content %}
-  <div class="page-header">
-    <h1>Lägg till lärare</h1>
+<div class="page-header">
+    <h1>Lägg till {{ form_name }}</h1>
     <a href="{{ url_for('admin.teachers') }}">Tillbaka</a>
   </div>
   <div class="col-md-4">

--- a/web/app/templates/admin/edit.html
+++ b/web/app/templates/admin/edit.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% import "bootstrap/wtf.html" as wtf %}
 
-{% block title %}Redigera lärare{% endblock %}
+{% block title %}Redigera {{ form_name }}{% endblock %}
 
 {% block page_content %}
-  <div class="page-header">
-    <h1>Redigera lärare</h1>
+<div class="page-header">
+    <h1>Redigera {{ form_name }}</h1>
     <a href="{{ url_for('admin.teachers') }}">Tillbaka</a>
   </div>
   <div class="col-md-4">

--- a/web/app/templates/admin/work-periods.html
+++ b/web/app/templates/admin/work-periods.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block page_content %}
+  <div class="row">
+    <div class="col-md-12">
+      <h1>Arbetsperioder</h1>
+      <a href="{{ url_for('admin.add_work_period') }}" class="btn btn-primary">Lägg till arbetsperiod</a>
+
+      <div class="input-group input-group">
+        <input type="text" id="search" class="form-control" placeholder="Sök">
+      </div>
+
+      <br>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Startdatum</th>
+            <th>Slutdatum</th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for work_period in work-periods %}
+            <tr class="teacher">
+              <td class="first-name">{{ work_period.start }}</td>
+              <td class="last-name">{{ work_period.end }}</td>
+              <td><a href="{{ url_for('admin.edit_work_period', id=work_period.id) }}" class="btn btn-primary">Redigera</a></td>
+              <td><a href="#" class="btn btn-danger">Ta bort</a></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/admin-search.js') }}"></script>
+{% endblock %}

--- a/web/app/templates/admin/work_periods.html
+++ b/web/app/templates/admin/work_periods.html
@@ -6,7 +6,8 @@
     <div class="col-md-12">
       <h1>Arbetsperioder</h1>
       <a href="{{ url_for('admin.add_work_period') }}" class="btn btn-primary">Lägg till arbetsperiod</a>
-
+      <br>
+      <br>
       <div class="input-group input-group">
         <input type="text" id="search" class="form-control" placeholder="Sök">
       </div>
@@ -22,7 +23,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for work_period in work-periods %}
+          {% for work_period in work_periods %}
             <tr class="teacher">
               <td class="first-name">{{ work_period.start }}</td>
               <td class="last-name">{{ work_period.end }}</td>


### PR DESCRIPTION
**Note:** This should be squashed when merged in order to remove commit `0d64fad` but keep it's changes

---

This is an initial version of this feature that is tested locally and working (although with bad UX atm)

Additionally...
- Updated the model for `WorkPeriod`s
- Updated `add.html` and `edit.html` to make them reusable for both
  `/teachers` and `/work-periods`
