### PR TITLE
Add .env.example file

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,12 @@
+CHRONOS_ADMIN=a@b.se
+CHRONOS_ADMIN_FIRST_NAME=Admin
+CHRONOS_ADMIN_LAST_NAME=Adminsson
+CHRONOS_ADMIN_PASSWORD=aaaaaa
+MAIL_USERNAME=user
+MAIL_PASSWORD=secretpassword
+CHRONOS_CONFIG=development
+DEV_DATABASE_URI=postgresql+psycopg2://postgres:secretpassword@localhost/development
+TEST_DATABASE_URI=postgresql+psycopg2://postgres:secretpassword@localhost/testing
+CELERY_DATABASE_URI=postgresql+psycopg2://postgres:secretpassword@localhost/development
+BROKER_URL=amqp://rabbitmq:secretpassword@localhost//
+RESULT_BACKEND=redis://localhost:6379/0


### PR DESCRIPTION
At the moment, one's required to create the .env based on information from
both chronos/wiki and development.rst. This could be an easier way to provide
the initial .env for new installations.

To use it, simply make a copy of the file. Whenever new keys are required, add
them to the .env.example in the same commit that introduced the change.
